### PR TITLE
Allow Sanntis summary file to be missing

### DIFF
--- a/mgnify_pipelines_toolkit/analysis/assembly/study_summary_generator.py
+++ b/mgnify_pipelines_toolkit/analysis/assembly/study_summary_generator.py
@@ -297,8 +297,7 @@ def generate_functional_summary(
             )
             logging.warning(e)
             return
-        else:
-            raise e
+        raise
 
     output_file_name = f"{output_prefix}_{label}_{OUTPUT_SUFFIX}"
 


### PR DESCRIPTION
This PR:
- adds an optional `allow_missing: bool` key to the expected files of Assembly Analysis Pipeline, specifying that the file is allowed to not be there and for that to not be an error.
- applies this to `sanntis`, for cases where `<ERZ...>_sanntis_summary.tsv.gz` is not present. This is the case in ASA, e.g. as of https://github.com/EBI-Metagenomics/assembly-analysis-pipeline/commit/c28287abd4424beec2ecf3e0b873f480691c70c5 an empty (header-only) Sanntis GFF does not emit a TSV.

There is a new test case for this.