### PR TITLE
Primer validation refactor

### DIFF
--- a/mgnify_pipelines_toolkit/analysis/amplicon/classify_var_regions.py
+++ b/mgnify_pipelines_toolkit/analysis/amplicon/classify_var_regions.py
@@ -62,6 +62,7 @@ def get_multiregion(raw_sequence_coords, regions):
 
     Returns:
         amplified_region: Amplified variable regions.
+        region_coverages: Coverage of all detected variable regions
 
     """
 
@@ -351,6 +352,8 @@ def retrieve_regions(
         )  # dictionary will contain read names for each variable region
         all_region_coverages = defaultdict(lambda: defaultdict(list))
         for read in data:
+            # Example structure of `read`
+            # ('ERR14650515.1', 'SSU_rRNA_archaea', 'RF01959', 'hmm', '3', '525', '1', '518', '+', '-', '6', '0.55', '0.6', '363.6', '7.8e-107')
             regions = determine_cm(read[2])
             sequence_counter_total += 1
             limits = list(map(int, read[4:6]))
@@ -397,18 +400,6 @@ def retrieve_regions(
                 )
             )
             continue
-
-        # filter out runs with too many sequences starting/ending inside variable regions
-        # internal_seq_fract = primer_inside_vr / len(data)
-        # if internal_seq_fract > MAX_INTERNAL_PRIMER_PROPORTION:
-        #     failed_run_counter += 1
-        #     logging.info("No output will be produced - too many internal mappings")
-        #     logging.info(
-        #         "Excluded due to high proportion of internal primers:\t{}\t{}\n".format(
-        #             tblout_file, "{0:.2f}".format(internal_seq_fract)
-        #         )
-        #     )
-        #     continue
 
         normalised_matches[run_id] = dict()
         region_counter = defaultdict(int)

--- a/mgnify_pipelines_toolkit/analysis/amplicon/classify_var_regions.py
+++ b/mgnify_pipelines_toolkit/analysis/amplicon/classify_var_regions.py
@@ -90,7 +90,7 @@ def check_primer_position(raw_sequence_coords, regions):
 
     """
     result_flag = False
-    margin = 3  # allowed margin of error
+    margin = 10  # allowed margin of error
     for coord in raw_sequence_coords:
         for region in regions.values():
             if coord in range(region[0] + margin, region[1] - margin):
@@ -432,14 +432,12 @@ def retrieve_regions(
             multiregion_matches[model] = new_value
 
         [multiregion_matches.pop(model) for model in models_to_remove]
-        print(multiregion_matches)
 
         run_status = "one"
         run_result = dict()
         total_useful_sequences = 0.0
         temp_seq_counter = dict()
         for model, model_regions in multiregion_matches.items():
-            print(model)
             result = normalise_results(model_regions)
             if result is None:
                 run_status = "ambiguous"

--- a/tests/unit/analysis/amplicon/classify_var_regions/test_classify_var_regions.yml
+++ b/tests/unit/analysis/amplicon/classify_var_regions/test_classify_var_regions.yml
@@ -15,3 +15,5 @@
       md5sum: aba8ff1cc6df1ce076633dd844b95d28
     - path: "sample.16S.V3-V4.txt"
       md5sum: 26b4cbbafdcfba30abb7ac561be0a40e
+    - path: "sample_all_coverages.txt"
+      md5sum: f81f5f1d60906f94589dd3dcf833da5e

--- a/tests/unit/analysis/amplicon/primer_val_classification/test_primer_val_classification.yml
+++ b/tests/unit/analysis/amplicon/primer_val_classification/test_primer_val_classification.yml
@@ -13,3 +13,7 @@
   files:
     - path: "test_primer_validation.tsv"
       md5sum: 953e749f8d42c4ac89cc84c4afd55731
+    - path: "fwd_primers.fasta"
+      md5sum: d3e8e54f8760c09532deaf1f699bd2e0
+    - path: "rev_primers.fasta"
+      md5sum: 85be59f336f4dd4b0419bfcfd62697fa


### PR DESCRIPTION
Two major changes:
- classify_var_regions 
    - Update so it no longer fails runs that have high internal variable region hits
    - Generates a new output file with the coverage metrics of variable regions, including minority ones
- primer_val_classification
    - Adds a margin of error allowing for primers that are at most 10 bases in a variable region
    - Now outputs primers into forward and reverse primer fasta files
    - New parameter to state the run is single_end, and if so, reverse_complement the reverse primer before writing it to the reverse primer fasta file