### PR TITLE
Fix/dwcr empty files support

### DIFF
--- a/mgnify_pipelines_toolkit/analysis/shared/dwc_summary_generator.py
+++ b/mgnify_pipelines_toolkit/analysis/shared/dwc_summary_generator.py
@@ -438,6 +438,9 @@ def get_asv_dict(runs_df: pd.DataFrame, root_path: Path, db: Literal["DADA2-SILV
         else:
             logging.info(f"Run {run_acc} does not seem to have ASV results for DB {db}, with mapseq file missing. Skipping.")
             continue
+        if mapseq_file.stat().st_size == 0:
+            logging.info(f"Run {run_acc}'s mapseq file {mapseq_file} exists but is empty. Skipping.")
+            continue
         mapseq_df = pd.read_csv(mapseq_file, sep="\t", usecols=[0, 1, 3, 9, 10])
         mapseq_df.columns = ["asv", "dbhit", "dbhitIdentity", "dbhitStart", "dbhitEnd"]
 
@@ -448,6 +451,10 @@ def get_asv_dict(runs_df: pd.DataFrame, root_path: Path, db: Literal["DADA2-SILV
         else:
             logging.info(f"Run {run_acc} does not seem to have ASV results for DB {db}, with asv tax file missing. Skipping.")
             continue
+        if tax_file.stat().st_size == 0:
+            logging.info(f"Run {run_acc}'s tax file {tax_file} exists but is empty. Skipping.")
+            continue
+
         run_tax_df = pd.read_csv(tax_file, sep="\t")
 
         # ASV read count files
@@ -463,6 +470,10 @@ def get_asv_dict(runs_df: pd.DataFrame, root_path: Path, db: Literal["DADA2-SILV
         else:
             logging.info(f"Run {run_acc} does not seem to have ASV FASTA sequence file. Skipping.")
             continue
+        if asv_fasta_file.stat().st_size == 0:
+            logging.info(f"Run {run_acc}'s asv_fasta file {asv_fasta_file} exists but is empty. Skipping.")
+            continue
+
         fasta = pyfastx.Fasta(str(asv_fasta_file), build_index=False)
         asv_fasta_dict = {name: seq for name, seq in fasta}
         asv_fasta_df = pd.DataFrame(asv_fasta_dict, index=["ASVSeq"]).transpose()
@@ -471,10 +482,16 @@ def get_asv_dict(runs_df: pd.DataFrame, root_path: Path, db: Literal["DADA2-SILV
         count_dfs = []
 
         for count_file in count_files:
+            if count_file.stat().st_size == 0:
+                logging.info(f"Run {run_acc}'s count file {count_files} exists but is empty. Skipping.")
+                continue
             amp_region = count_file.stem.split("_")[1]
             count_df = pd.read_csv(count_file, sep="\t")
             count_df["amplifiedRegion"] = [amp_region] * len(count_df)
             count_dfs.append(count_df)
+        if not count_dfs:
+            logging.info(f"Run {run_acc}'s count dataframe {count_files} is empty. Skipping.")
+            continue
 
         # Merge counts into one DF in case there are multiple amplified regions...
         all_amplified_regions_count_df = pd.concat(count_dfs)
@@ -545,6 +562,9 @@ def get_closedref_dict(
             kronatxt_file = kronatxt_file[0]
         else:
             logging.info(f"Run {run_acc} doesn't have closed-reference results for DB {db}, skipping it.")
+            continue
+        if kronatxt_file.stat().st_size == 0:
+            logging.info(f"Run {run_acc}'s krona txt file {kronatxt_file} exists but is empty. Skipping.")
             continue
 
         column_names = ["count"] + ranks

--- a/mgnify_pipelines_toolkit/analysis/shared/dwc_summary_generator.py
+++ b/mgnify_pipelines_toolkit/analysis/shared/dwc_summary_generator.py
@@ -435,12 +435,13 @@ def get_asv_dict(runs_df: pd.DataFrame, root_path: Path, db: Literal["DADA2-SILV
         mapseq_file = sorted(list((Path(root_path) / run_acc / "taxonomy-summary" / db).glob(f"*_{db}.mseq")))
         if mapseq_file:
             mapseq_file = mapseq_file[0]
+            if mapseq_file.stat().st_size == 0:
+                logging.info(f"Run {run_acc}'s mapseq file {mapseq_file} exists but is empty. Skipping.")
+                continue
         else:
             logging.info(f"Run {run_acc} does not seem to have ASV results for DB {db}, with mapseq file missing. Skipping.")
             continue
-        if mapseq_file.stat().st_size == 0:
-            logging.info(f"Run {run_acc}'s mapseq file {mapseq_file} exists but is empty. Skipping.")
-            continue
+
         mapseq_df = pd.read_csv(mapseq_file, sep="\t", usecols=[0, 1, 3, 9, 10])
         mapseq_df.columns = ["asv", "dbhit", "dbhitIdentity", "dbhitStart", "dbhitEnd"]
 
@@ -448,30 +449,24 @@ def get_asv_dict(runs_df: pd.DataFrame, root_path: Path, db: Literal["DADA2-SILV
         tax_file = sorted(list((Path(root_path) / run_acc / "asv").glob(f"*_{db}_asv_tax.tsv")))
         if tax_file:
             tax_file = tax_file[0]
+            if tax_file.stat().st_size == 0:
+                logging.info(f"Run {run_acc}'s tax file {tax_file} exists but is empty. Skipping.")
+                continue
         else:
             logging.info(f"Run {run_acc} does not seem to have ASV results for DB {db}, with asv tax file missing. Skipping.")
             continue
-        if tax_file.stat().st_size == 0:
-            logging.info(f"Run {run_acc}'s tax file {tax_file} exists but is empty. Skipping.")
-            continue
 
         run_tax_df = pd.read_csv(tax_file, sep="\t")
-
-        # ASV read count files
-        count_files = sorted(list(Path(f"{root_path}/{run_acc}/asv").glob("*S-V*/*.tsv")))
-        if not count_files:
-            logging.info(f"Run {run_acc} missing count files for some reason, cannot generate ASV summaries. Skipping.")
-            continue
 
         # ASV sequence FASTA files
         asv_fasta_file = sorted(list(Path(f"{root_path}/{run_acc}/asv").glob("*_asv_seqs.fasta")))
         if asv_fasta_file:
             asv_fasta_file = asv_fasta_file[0]
+            if asv_fasta_file.stat().st_size == 0:
+                logging.info(f"Run {run_acc}'s asv_fasta file {asv_fasta_file} exists but is empty. Skipping.")
+                continue
         else:
             logging.info(f"Run {run_acc} does not seem to have ASV FASTA sequence file. Skipping.")
-            continue
-        if asv_fasta_file.stat().st_size == 0:
-            logging.info(f"Run {run_acc}'s asv_fasta file {asv_fasta_file} exists but is empty. Skipping.")
             continue
 
         fasta = pyfastx.Fasta(str(asv_fasta_file), build_index=False)
@@ -479,8 +474,13 @@ def get_asv_dict(runs_df: pd.DataFrame, root_path: Path, db: Literal["DADA2-SILV
         asv_fasta_df = pd.DataFrame(asv_fasta_dict, index=["ASVSeq"]).transpose()
         asv_fasta_df["asv"] = asv_fasta_df.index
 
-        count_dfs = []
+        # ASV read count files
+        count_files = sorted(list(Path(f"{root_path}/{run_acc}/asv").glob("*S-V*/*.tsv")))
+        if not count_files:
+            logging.info(f"Run {run_acc} missing count files for some reason, cannot generate ASV summaries. Skipping.")
+            continue
 
+        count_dfs = []
         for count_file in count_files:
             if count_file.stat().st_size == 0:
                 logging.info(f"Run {run_acc}'s count file {count_files} exists but is empty. Skipping.")
@@ -560,11 +560,11 @@ def get_closedref_dict(
         kronatxt_file = sorted(list((pathlib.Path(root_path) / run_acc / "taxonomy-summary" / f"{db}").glob("*.txt")))
         if kronatxt_file:
             kronatxt_file = kronatxt_file[0]
+            if kronatxt_file.stat().st_size == 0:
+                logging.info(f"Run {run_acc}'s krona txt file {kronatxt_file} exists but is empty. Skipping.")
+                continue
         else:
             logging.info(f"Run {run_acc} doesn't have closed-reference results for DB {db}, skipping it.")
-            continue
-        if kronatxt_file.stat().st_size == 0:
-            logging.info(f"Run {run_acc}'s krona txt file {kronatxt_file} exists but is empty. Skipping.")
             continue
 
         column_names = ["count"] + ranks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgnify_pipelines_toolkit"
-version = "1.4.24"
+version = "1.5.0"
 readme = "README.md"
 license = { text = "Apache Software License 2.0" }
 authors = [

--- a/tests/unit/analysis/shared/dwc_summary_generator/test_dwc_summary_generator.py
+++ b/tests/unit/analysis/shared/dwc_summary_generator/test_dwc_summary_generator.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright 2024-2025 EMBL - European Bioinformatics Institute
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+import shutil
+from pathlib import Path
+from mgnify_pipelines_toolkit.analysis.shared.dwc_summary_generator import get_asv_dict, get_closedref_dict
+
+
+def test_get_asv_dict_empty_files(tmp_path: Path):
+    """
+    Test get_asv_dict to ensure it correctly skips runs with empty critical files.
+    """
+    # Setup
+    run_acc = "ERR123456"
+    runs_df = pd.DataFrame([{"run": run_acc, "status": "all_results"}])
+    db = "DADA2-SILVA"
+    otu_dir = tmp_path / "otu"
+    otu_dir.mkdir()
+
+    # Use the fixture OTU file instead of creating a dummy one
+    fixture_otu = Path("tests/fixtures/refdb_otus/SILVA-SSU.otu")
+    shutil.copy(fixture_otu, otu_dir / "SILVA-SSU.otu")
+
+    root_path = tmp_path / "results"
+    run_dir = root_path / run_acc
+    tax_summary_dir = run_dir / "taxonomy-summary" / db
+    asv_dir = run_dir / "asv"
+
+    tax_summary_dir.mkdir(parents=True)
+    asv_dir.mkdir(parents=True)
+
+    # Files to be tested
+    mapseq_file = tax_summary_dir / f"test_{db}.mseq"
+    tax_file = asv_dir / f"test_{db}_asv_tax.tsv"
+    asv_fasta_file = asv_dir / "test_asv_seqs.fasta"
+    count_dir = asv_dir / "16S-V3-V4"
+    count_dir.mkdir()
+    count_file = count_dir / "test_16S-V3-V4_counts.tsv"
+
+    # 1. Test mapseq_file empty
+    mapseq_file.touch()
+    tax_file.write_text("dummy")
+    asv_fasta_file.write_text("dummy")
+    count_file.write_text("dummy")
+
+    res = get_asv_dict(runs_df, root_path, db, otu_dir)
+    assert run_acc not in res
+
+    # 2. Test tax_file empty
+    mapseq_file.write_text(
+        "asv\tdbhit\tdbhitEval\tdbhitIdentity\tdbhitQueryStart\tdbhitQueryEnd\tdbhitTargetStart\tdbhitTargetEnd\tdbhitScore\tdbhitStart\tdbhitEnd\nASV1\thit1\t0.0\t100.0\t1\t100\t1\t100\t100\t1\t100\n"
+    )
+    tax_file.write_text("")  # Empty
+    res = get_asv_dict(runs_df, root_path, db, otu_dir)
+    assert run_acc not in res
+
+    # 3. Test asv_fasta_file empty
+    tax_file.write_text(
+        "ASV\tSuperkingdom\tKingdom\tPhylum\tClass\tOrder\tFamily\tGenus\tSpecies\nASV1\td__Bacteria\tk__Kingdom\tp__Phylum\tc__Class\to__Order\tf__Family\tg__Genus\ts__Species\n"
+    )
+    asv_fasta_file.write_text("")  # Empty
+    res = get_asv_dict(runs_df, root_path, db, otu_dir)
+    assert run_acc not in res
+
+    # 4. Test count_file empty
+    asv_fasta_file.write_text(">ASV1\nATGC\n")
+    count_file.write_text("")  # Empty
+    res = get_asv_dict(runs_df, root_path, db, otu_dir)
+    assert run_acc not in res
+
+    # 5. Test with mixed count files (one empty, one not)
+    count_file.write_text("asv\tcount\nASV1\t10\n")  # non-empty
+    count_file_2 = count_dir / "test2_18S-V4_counts.tsv"
+    count_file_2.touch()  # empty
+
+    # It should NOT skip the run because count_file is non-empty
+    res = get_asv_dict(runs_df, root_path, db, otu_dir)
+    assert run_acc in res
+    assert len(res[run_acc]) == 1
+    assert res[run_acc].iloc[0]["asv"] == "ASV1"
+
+
+def test_get_closedref_dict_empty_files(tmp_path: Path):
+    """
+    Test get_closedref_dict to ensure it correctly skips runs with empty krona files.
+    """
+    # Setup
+    run_acc = "ERR123456"
+    runs_df = pd.DataFrame([{"run": run_acc, "status": "all_results"}])
+    db = "SILVA-SSU"
+    otu_dir = tmp_path / "otu"
+    otu_dir.mkdir()
+
+    root_path = tmp_path / "results"
+    run_dir = root_path / run_acc
+    tax_summary_dir = run_dir / "taxonomy-summary" / db
+    tax_summary_dir.mkdir(parents=True)
+
+    kronatxt_file = tax_summary_dir / "test.krona.txt"
+    kronatxt_file.touch()  # Empty
+
+    res = get_closedref_dict(runs_df, root_path, db, otu_dir)
+    assert run_acc not in res
+
+    # Test non-empty krona file
+    kronatxt_file.write_text("10\td__Bacteria\tp__Phylum\tc__Class\to__Order\tf__Family\tg__Genus\ts__Species\n")
+
+    # Use the fixture OTU file
+    fixture_otu = Path("tests/fixtures/refdb_otus/SILVA-SSU.otu")
+    shutil.copy(fixture_otu, otu_dir / "SILVA-SSU.otu")
+
+    res = get_closedref_dict(runs_df, root_path, db, otu_dir)
+    assert run_acc in res
+    assert res[run_acc].iloc[0]["count"] == 10


### PR DESCRIPTION
It's possible to get some results files used by the DwC-R generator that exist but are empty, which would cause a failure when pandas attempts to read the files. This PR fixes that.

> [!CAUTION]
> The unit tests were mostly written using Junie 