### PR TITLE
add check for when the input path exists but is empty

### DIFF
--- a/mgnify_pipelines_toolkit/analysis/amplicon/mapseq_to_asv_table.py
+++ b/mgnify_pipelines_toolkit/analysis/amplicon/mapseq_to_asv_table.py
@@ -133,12 +133,16 @@ def process_blank_tax_ends(res_df, ranks):
 def main():
     input_path, label, sample = parse_args()
 
+    mapseq_to_asv_table(input_path, label, sample)
+
+
+def mapseq_to_asv_table(input_path: Path, label: str, sample: str):
     res_tsv_name = f"./{sample}_{label}_asv_taxa.tsv"
 
     if input_path.stat().st_size == 0:
         logging.info(f"Run {sample}'s mapseq file {input_path} exists but is empty. Skipping.")
         open(res_tsv_name, "w").close()
-        exit(0)
+        return
 
     mseq_df = pd.read_csv(input_path, header=0, delim_whitespace=True, usecols=[0, 12])
 

--- a/mgnify_pipelines_toolkit/analysis/amplicon/mapseq_to_asv_table.py
+++ b/mgnify_pipelines_toolkit/analysis/amplicon/mapseq_to_asv_table.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+from pathlib import Path
 import logging
 from collections import defaultdict
 
@@ -30,9 +31,9 @@ from mgnify_pipelines_toolkit.constants.tax_ranks import (
 logging.basicConfig(level=logging.DEBUG)
 
 
-def parse_args():
+def parse_args() -> tuple[Path, str, str]:
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--input", required=True, type=str, help="Input from MAPseq output")
+    parser.add_argument("-i", "--input", required=True, type=Path, help="Input from MAPseq output")
     parser.add_argument(
         "-l",
         "--label",
@@ -45,11 +46,11 @@ def parse_args():
 
     args = parser.parse_args()
 
-    input = args.input
+    input_path = args.input
     label = args.label
     sample = args.sample
 
-    return input, label, sample
+    return input_path, label, sample
 
 
 def parse_label(label: str) -> tuple[list[str], list[str]]:
@@ -130,9 +131,17 @@ def process_blank_tax_ends(res_df, ranks):
 
 
 def main():
-    input, label, sample = parse_args()
+    input_path, label, sample = parse_args()
 
-    mseq_df = pd.read_csv(input, header=0, delim_whitespace=True, usecols=[0, 12])
+    res_tsv_name = f"./{sample}_{label}_asv_taxa.tsv"
+
+    if input_path.stat().st_size == 0:
+        logging.info(f"Run {sample}'s mapseq file {input_path} exists but is empty. Skipping.")
+        open(res_tsv_name, "w").close()
+        exit(0)
+
+    mseq_df = pd.read_csv(input_path, header=0, delim_whitespace=True, usecols=[0, 12])
+
     logging.info(f"Number of ASVs at start: {len(mseq_df)}")
 
     short_ranks, long_ranks = parse_label(label)
@@ -140,7 +149,6 @@ def main():
     final_res_df = process_blank_tax_ends(res_df, short_ranks)
     logging.info(f"Number of ASVs at end: {len(final_res_df)}")
 
-    res_tsv_name = f"./{sample}_{label}_asv_taxa.tsv"
     final_res_df.to_csv(res_tsv_name, sep="\t", index=False) if not final_res_df.empty else open(res_tsv_name, "w").close()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgnify_pipelines_toolkit"
-version = "1.5.1"
+version = "1.5.2"
 readme = "README.md"
 license = { text = "Apache Software License 2.0" }
 authors = [

--- a/tests/unit/analysis/amplicon/mapseq_to_asv_table/test_mapseq_to_asv_table.py
+++ b/tests/unit/analysis/amplicon/mapseq_to_asv_table/test_mapseq_to_asv_table.py
@@ -1,0 +1,96 @@
+import logging
+import pandas as pd
+from mgnify_pipelines_toolkit.analysis.amplicon.mapseq_to_asv_table import parse_label, parse_mapseq, process_blank_tax_ends, mapseq_to_asv_table
+from mgnify_pipelines_toolkit.constants.tax_ranks import (
+    SHORT_SILVA_TAX_RANKS,
+    SILVA_TAX_RANKS,
+)
+
+
+def test_parse_label():
+    """
+    Test that parse_label returns the correct short and long ranks for a given database label.
+    """
+    short_ranks, long_ranks = parse_label("DADA2-SILVA")
+    assert short_ranks == [f"{rank}__" for rank in SHORT_SILVA_TAX_RANKS]
+    assert long_ranks == SILVA_TAX_RANKS
+
+
+def test_parse_mapseq():
+    """
+    Test that parse_mapseq correctly converts MAPseq taxonomy strings into a structured DataFrame.
+    """
+    short_ranks = ["k__", "p__", "c__"]
+    long_ranks = ["Kingdom", "Phylum", "Class"]
+    mseq_data = {"query": ["ASV1", "ASV2"], "tax": ["k__Bacteria;p__Firmicutes", "k__Archaea"]}
+    mseq_df = pd.DataFrame(mseq_data)
+
+    res_df = parse_mapseq(mseq_df, short_ranks, long_ranks)
+
+    assert len(res_df) == 2
+    assert list(res_df.columns) == ["ASV", "Kingdom", "Phylum", "Class"]
+
+    assert res_df.iloc[0]["ASV"] == "ASV1"
+    assert res_df.iloc[0]["Kingdom"] == "k__Bacteria"
+    assert res_df.iloc[0]["Phylum"] == "p__Firmicutes"
+    assert res_df.iloc[0]["Class"] == "c__"
+
+    assert res_df.iloc[1]["ASV"] == "ASV2"
+    assert res_df.iloc[1]["Kingdom"] == "k__Archaea"
+    assert res_df.iloc[1]["Phylum"] == "p__"
+    assert res_df.iloc[1]["Class"] == "c__"
+
+
+def test_process_blank_tax_ends():
+    """
+    Test that process_blank_tax_ends correctly replaces trailing empty ranks with 'NA'.
+    """
+    ranks = ["k__", "p__", "c__"]
+    df = pd.DataFrame(
+        {
+            "ASV": ["ASV1", "ASV2", "ASV3"],
+            "Kingdom": ["k__Bacteria", "k__Archaea", "k__"],
+            "Phylum": ["p__Firmicutes", "p__", "p__"],
+            "Class": ["c__", "c__", "c__"],
+        }
+    )
+
+    processed_df = process_blank_tax_ends(df, ranks)
+
+    # ASV1: Kingdom=Bacteria, Phylum=Firmicutes, Class=c__ (empty) -> Class should be NA
+    assert processed_df.iloc[0]["Class"] == "NA"
+    assert processed_df.iloc[0]["Phylum"] == "p__Firmicutes"
+
+    # ASV2: Kingdom=Archaea, Phylum=p__ (empty), Class=c__ (empty) -> Phylum and Class should be NA
+    assert processed_df.iloc[1]["Class"] == "NA"
+    assert processed_df.iloc[1]["Phylum"] == "NA"
+    assert processed_df.iloc[1]["Kingdom"] == "k__Archaea"
+
+    # ASV3: All empty -> Phylum and Class should be NA, Kingdom should stay k__
+    assert processed_df.iloc[2]["Class"] == "NA"
+    assert processed_df.iloc[2]["Phylum"] == "NA"
+    assert processed_df.iloc[2]["Kingdom"] == "k__"
+
+
+def test_mapseq_to_asv_table_empty_input(tmp_path, monkeypatch, caplog):
+    """
+    Test that mapseq_to_asv_table handles an empty input file correctly.
+    Similar to tests in test_dwc_summary_generator.py.
+    """
+    caplog.set_level(logging.INFO)
+
+    input_file = tmp_path / "input.mseq"
+    input_file.touch()
+
+    sample = "test_sample"
+    label = "DADA2-SILVA"
+
+    # Need to change directory because the function currently hardcodes "./" output
+    monkeypatch.chdir(tmp_path)
+
+    mapseq_to_asv_table(input_file, label, sample)
+
+    output_file = tmp_path / f"{sample}_{label}_asv_taxa.tsv"
+    assert output_file.exists()
+    assert output_file.stat().st_size == 0
+    assert f"Run {sample}'s mapseq file {input_file} exists but is empty. Skipping." in caplog.text


### PR DESCRIPTION
https://github.com/EBI-Metagenomics/mgnify-pipelines-toolkit/pull/154 fixed a bug that could happen when some results files were empty. This PR pre-emptively fixes a similar case that could happen one day

> [!CAUTION]
> The unit test was mostly written by Junie 