### PR TITLE
EMG-9948 Improve robustness of amplicon summaries generating scripts

### DIFF
--- a/mgnify_pipelines_toolkit/analysis/shared/dwc_summary_generator.py
+++ b/mgnify_pipelines_toolkit/analysis/shared/dwc_summary_generator.py
@@ -490,7 +490,7 @@ def get_asv_dict(runs_df: pd.DataFrame, root_path: Path, db: Literal["DADA2-SILV
             count_df["amplifiedRegion"] = [amp_region] * len(count_df)
             count_dfs.append(count_df)
         if not count_dfs:
-            logging.info(f"Run {run_acc}'s count dataframe {count_files} is empty. Skipping.")
+            logging.info(f"Run {run_acc}'s count file {count_file} exists but is empty. Skipping.")
             continue
 
         # Merge counts into one DF in case there are multiple amplified regions...
@@ -676,7 +676,15 @@ def generate_dwcready_summaries(runs: Path, analyses_dir: Path, output_prefix: s
                 run_merged_result = run_metadata.merge(run_asv_data, on="RunID")
                 all_merged_df.append(run_merged_result)
 
+        if not all_merged_df:
+            logging.info(f"No ASV results found for DB {db} across runs; skipping generation of *_dwcready.csv.")
+            continue
+
         final_df = pd.concat(all_merged_df, ignore_index=True)
+        if final_df.empty:
+            logging.info(f"Concatenated ASV dataframe for DB {db} is empty; skipping generation of *_dwcready.csv.")
+            continue
+
         final_df = cleanup_asv_taxa(final_df, db)
 
         # get all amplified regions present in the study
@@ -695,6 +703,10 @@ def generate_dwcready_summaries(runs: Path, analyses_dir: Path, output_prefix: s
     closedref_dbs = ["SILVA-SSU", "PR2", "SILVA-LSU", "ITSoneDB", "UNITE"]
     for db in closedref_dbs:
         closedref_dict = get_closedref_dict(runs_df, root_path, db, otu_dir)
+        if not closedref_dict:
+            logging.info(f"No closed-reference data found for DB {db}, skipping generation of *_closedref_{db}_dwcready.csv.")
+            continue
+
         all_merged_df = []
 
         for run in all_runs:
@@ -710,7 +722,7 @@ def generate_dwcready_summaries(runs: Path, analyses_dir: Path, output_prefix: s
 
             final_df.to_csv(f"{output_prefix}_closedref_{db}_dwcready.csv", index=False, na_rep="NA")
         else:
-            logging.info(f"No results at all for DB {db} in entire analysis, won't generate summary for it.")
+            logging.info(f"No results at all for DB {db} in entire study, won't generate *_closedref_{db}_dwcready.csv.")
 
 
 def organise_dwcr_summaries(all_study_summaries: List[Path]) -> defaultdict[List]:

--- a/mgnify_pipelines_toolkit/analysis/shared/dwc_summary_generator.py
+++ b/mgnify_pipelines_toolkit/analysis/shared/dwc_summary_generator.py
@@ -406,14 +406,14 @@ def get_asv_dict(runs_df: pd.DataFrame, root_path: Path, db: Literal["DADA2-SILV
         count_dfs = []
         for count_file in count_files:
             if count_file.stat().st_size == 0:
-                logging.info(f"Run {run_acc}'s count file {count_files} exists but is empty. Skipping.")
+                logging.info(f"Run {run_acc}'s count file {count_file} exists but is empty. Skipping.")
                 continue
             amp_region = count_file.stem.split("_")[1]
             count_df = pd.read_csv(count_file, sep="\t")
             count_df["amplifiedRegion"] = [amp_region] * len(count_df)
             count_dfs.append(count_df)
         if not count_dfs:
-            logging.info(f"Run {run_acc}'s count file {count_file} exists but is empty. Skipping.")
+            logging.info(f"Run {run_acc} does not seem to have any ASV count data. Skipping.")
             continue
 
         # Merge counts into one DF in case there are multiple amplified regions...

--- a/mgnify_pipelines_toolkit/analysis/shared/dwc_summary_generator.py
+++ b/mgnify_pipelines_toolkit/analysis/shared/dwc_summary_generator.py
@@ -21,12 +21,12 @@ import shutil
 from collections import defaultdict
 from pathlib import Path
 from shutil import SameFileError
-from typing import Dict, List, Literal, Union
+from typing import Dict, List, Literal
 
 import click
 import pandas as pd
 import pyfastx
-import requests
+import json
 
 from mgnify_pipelines_toolkit.constants.tax_ranks import (
     PR2_TAX_RANKS,
@@ -36,9 +36,6 @@ from mgnify_pipelines_toolkit.constants.tax_ranks import (
 )
 
 logging.basicConfig(level=logging.DEBUG)
-
-URL = "https://www.ebi.ac.uk/ena/portal/api/search"
-HEADERS = {"Accept": "application/json"}
 
 
 @click.group()
@@ -71,120 +68,6 @@ def parse_args():
     output = args.output
 
     return input_path, runs, output
-
-
-def get_ena_metadata_from_run_acc(run_acc: str) -> Union[pd.DataFrame, bool]:
-    """
-    Fetches and processes metadata from ENA using the provided run accession.
-
-    This function queries the European Nucleotide Archive (ENA) API to retrieve
-    metadata related to the specified run accession. Once the metadata is
-    retrieved, it performs cleaning and formatting to return the data in a
-    structured pandas DataFrame.
-
-    Parameters:
-    run_acc: str
-        Accession identifier for the run to query from ENA.
-
-    Returns:
-    Union[pd.DataFrame, bool]
-        A pandas DataFrame containing the retrieved and processed metadata
-        if the query is successful, or False if the data for the given run
-        accession is not found.
-    """
-
-    run_fields_list = [
-        "secondary_study_accession",
-        "sample_accession",
-        "instrument_model",
-    ]
-    run_query_args = {
-        "result": "read_run",
-        "includeAccessions": run_acc,
-        "fields": ",".join(run_fields_list),
-        "limit": 10,
-        "format": "json",
-        "download": "false",
-    }
-    res_run = requests.get(URL, headers=HEADERS, params=run_query_args)
-
-    if res_run.status_code != 200:
-        logging.error(f"Data not found for run {run_acc}")
-        return False
-
-    sample_acc = res_run.json()[0]["sample_accession"]
-    sample_fields_list = [
-        "lat",
-        "lon",
-        "collection_date",
-        "depth",
-        "center_name",
-        "temperature",
-        "salinity",
-        "country",
-    ]
-    sample_query_args = {
-        "result": "sample",
-        "includeAccessions": sample_acc,
-        "fields": ",".join(sample_fields_list),
-        "limit": 10,
-        "format": "json",
-        "download": "false",
-    }
-    res_sample = requests.get(URL, headers=HEADERS, params=sample_query_args)
-
-    full_res_dict = res_run.json()[0] | res_sample.json()[0]
-
-    # Turn empty values into NA
-    full_res_dict = {field: "NA" if val == "" else val for field, val in full_res_dict.items()}
-
-    if full_res_dict["collection_date"] == "":
-        full_res_dict["collectionDate"] = "NA"
-    else:
-        full_res_dict["collectionDate"] = full_res_dict["collection_date"]
-
-    del full_res_dict["collection_date"]
-
-    res_df = pd.DataFrame(full_res_dict, index=[0])
-    res_df = res_df.rename(
-        columns={
-            "run_accession": "RunID",
-            "sample_accession": "SampleID",
-            "secondary_study_accession": "StudyID",
-            "lon": "decimalLongitude",
-            "lat": "decimalLatitude",
-            "instrument_model": "seq_meth",
-        }
-    )
-
-    return res_df
-
-
-def get_all_ena_metadata_from_runs(runs: List[str]) -> Dict[str, pd.DataFrame]:
-    """
-    Fetches ENA metadata for a list of run accessions.
-
-    This function retrieves metadata from the European Nucleotide Archive (ENA)
-    for the provided list of run accessions. For each valid run accession, the
-    metadata is parsed and stored in a dictionary, where the key is the run
-    accession and the value is a DataFrame containing the metadata.
-
-    Parameters:
-        runs (List[str]): A list of strings representing run accessions for which
-            the metadata needs to be retrieved.
-
-    Returns:
-        Dict[str, pd.DataFrame]: A dictionary where keys are run accessions and
-        values are DataFrames containing the corresponding ENA metadata.
-    """
-    run_metadata_dict = defaultdict(pd.DataFrame)
-
-    for run in runs:
-        res_df = get_ena_metadata_from_run_acc(run)
-        if res_df is not False:
-            run_metadata_dict[run] = res_df
-
-    return run_metadata_dict
 
 
 def cleanup_asv_taxa(df: pd.DataFrame, db: Literal["DADA2-SILVA", "DADA2-PR2"]) -> pd.DataFrame:
@@ -333,6 +216,46 @@ def cleanup_closedref_taxa(df: pd.DataFrame, db: Literal["SILVA-SSU", "PR2", "SI
     ]
 
     return cleaned_df
+
+
+def load_run_metadata_from_json(metadata_path: Path, runs: List[str]) -> Dict[str, pd.DataFrame]:
+    """
+    Load per-run metadata from a JSON file and return a mapping of run -> DataFrame.
+
+    Expected JSON file example:
+
+    {
+      "ERR000001": {
+        "RunID": "ERR000001",
+        "SampleID": "SAME1",
+        "StudyID": "PRJXXXX",
+        "decimalLatitude": "51.5",
+        "decimalLongitude": "-0.12",
+        "collectionDate": "2020-01-01",
+        "seq_meth": "Illumina MiSeq",
+        "country": "United Kingdom",
+        "InstitutionCode": "EMBL-EBI"
+      },
+      "ERR000002": { ... }
+    }
+
+    The function ensures each metadata dict contains a `RunID` (defaults to the
+    run accession key if missing) and converts each entry to a single-row
+    pandas DataFrame, replacing nulls with the string "NA".
+    """
+    with metadata_path.open("r") as fh:
+        metadata_json = json.load(fh)
+
+    run_metadata: Dict[str, pd.DataFrame] = {}
+    for run in runs:
+        if run in metadata_json:
+            md = metadata_json[run]
+            if "RunID" not in md:
+                md["RunID"] = run
+            run_df = pd.DataFrame(md, index=[0]).fillna("NA")
+            run_metadata[run] = run_df
+
+    return run_metadata
 
 
 def concatenate_taxa_row(taxa_row: pd.Series, separator: str = ";") -> str:
@@ -613,8 +536,15 @@ def get_closedref_dict(
     help="Input directory containing the OTU files for the taxonomic reference databases to extract taxonomic IDs",
     type=click.Path(exists=True, path_type=Path, file_okay=False),
 )
+@click.option(
+    "-m",
+    "--metadata",
+    required=True,
+    help="Path to JSON file containing per-run metadata (mapping run -> metadata dict)",
+    type=click.Path(exists=True, path_type=Path, dir_okay=False),
+)
 @click.option("-p", "--output_prefix", required=True, help="Prefix to summary files", type=str)
-def generate_dwcready_summaries(runs: Path, analyses_dir: Path, output_prefix: str, otu_dir: Path) -> None:
+def generate_dwcready_summaries(runs: Path, analyses_dir: Path, otu_dir: Path, metadata: Path, output_prefix: str) -> None:
     """
     Generate Darwin Core-ready study-level summaries of amplicon analysis results.
 
@@ -661,7 +591,12 @@ def generate_dwcready_summaries(runs: Path, analyses_dir: Path, output_prefix: s
     runs_df = pd.read_csv(runs, names=["run", "status"])
 
     all_runs = runs_df.run.to_list()
-    run_metadata_dict = get_all_ena_metadata_from_runs(all_runs)
+
+    try:
+        run_metadata_dict = load_run_metadata_from_json(metadata, all_runs)
+    except Exception as exc:
+        logging.error(f"Failed to load metadata from {metadata}: {exc}")
+        exit(1)
 
     # Generate DwC-ready files for ASV results
     asv_dbs = ["DADA2-SILVA", "DADA2-PR2"]

--- a/mgnify_pipelines_toolkit/analysis/shared/markergene_study_summary.py
+++ b/mgnify_pipelines_toolkit/analysis/shared/markergene_study_summary.py
@@ -30,7 +30,6 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def parse_args():
-
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-i",
@@ -58,7 +57,6 @@ def parse_args():
 
 
 def get_read_count(read_path):
-
     fasta = pyfastx.Fasta(read_path, build_index=False)
     read_count = sum(1 for _ in fasta)
 
@@ -66,9 +64,7 @@ def get_read_count(read_path):
 
 
 def add_markergene(root_path, run_acc, markergene_dict, markergene):
-
     if markergene != "ITS":
-
         bacterial_ssu = list(pathlib.Path(f"{root_path}/{run_acc}/sequence-categorisation").glob(f"*{markergene}*bacteria*"))
         archaeal_ssu = list(pathlib.Path(f"{root_path}/{run_acc}/sequence-categorisation").glob(f"*{markergene}*archaea*"))
         eukarya_ssu = list(pathlib.Path(f"{root_path}/{run_acc}/sequence-categorisation").glob(f"*{markergene}*eukarya*"))
@@ -91,7 +87,6 @@ def add_markergene(root_path, run_acc, markergene_dict, markergene):
 
 
 def add_read_count_to_markergene(marker_gene_dict, marker, label):
-
     if marker:
         read_count = get_read_count(str(marker[0]))
         marker_gene_dict[label]["read_count"] = read_count
@@ -102,7 +97,6 @@ def add_read_count_to_markergene(marker_gene_dict, marker, label):
 
 
 def main():
-
     input_path, runs, prefix = parse_args()
 
     root_path = pathlib.Path(input_path)
@@ -158,7 +152,12 @@ def main():
             marker_gene = amp_region.split("-")[0]
             amp_region = "-".join(amp_region.split("-")[1:])
 
-            amp_region_df = pd.read_csv(amp_region_path, sep="\t")
+            try:
+                amp_region_df = pd.read_csv(amp_region_path, sep="\t")
+            except pd.errors.EmptyDataError:
+                logging.warning(f"ASV TSV is empty, skipping: {amp_region_path}")
+                continue
+
             asv_count = len(amp_region_df)
             read_count = amp_region_df.loc[:, "count"].sum()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgnify_pipelines_toolkit"
-version = "1.5.1"
+version = "1.5.2"
 readme = "README.md"
 license = { text = "Apache Software License 2.0" }
 authors = [

--- a/tests/fixtures/study_summary_inputs/amplicon/qc_passed_runs_5_metadata.json
+++ b/tests/fixtures/study_summary_inputs/amplicon/qc_passed_runs_5_metadata.json
@@ -1,0 +1,30 @@
+{
+  "ERR4334351": {
+    "RunID": "ERR4334351",
+    "StudyID": "ERP122862",
+    "SampleID": "SAMEA7057179",
+    "seq_meth": "Illumina MiSeq",
+    "decimalLatitude": 51.112278,
+    "decimalLongitude": 10.408889,
+    "depth": 0.1,
+    "center_name": "FRIEDRICH SCHILLER UNIVERSITY JENA",
+    "temperature": null,
+    "salinity": null,
+    "country": "Germany",
+    "collectionDate": "2018-05-02"
+  },
+  "SRR17062740": {
+    "RunID": "SRR17062740",
+    "StudyID": "SRP348338",
+    "SampleID": "SAMN23489005",
+    "seq_meth": "Illumina MiSeq",
+    "decimalLatitude": 56.184167,
+    "decimalLongitude": 10.239167,
+    "depth": null,
+    "center_name": "University of Southern Denmark",
+    "temperature": null,
+    "salinity": null,
+    "country": "Denmark: Arhus Arhus Bay",
+    "collectionDate": "2017-01-18"
+  }
+}

--- a/tests/unit/analysis/shared/dwc_summary_generator/test_dwc_summary_generator.py
+++ b/tests/unit/analysis/shared/dwc_summary_generator/test_dwc_summary_generator.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import pandas as pd
 import shutil
 from pathlib import Path
@@ -177,7 +178,7 @@ def test_generate_dwcready_summaries_single_run_empty_asv(tmp_path: Path):
     # Create minimal metadata JSON mapping for the run and pass via -m
     metadata = {run_acc: {"RunID": run_acc, "SampleID": "SAMPLE1"}}
     metadata_file = tmp_path / "metadata.json"
-    metadata_file.write_text(pd.io.json.dumps(metadata))
+    metadata_file.write_text(json.dumps(metadata))
 
     result = runner.invoke(
         cli,

--- a/tests/unit/analysis/shared/dwc_summary_generator/test_dwc_summary_generator.py
+++ b/tests/unit/analysis/shared/dwc_summary_generator/test_dwc_summary_generator.py
@@ -18,6 +18,8 @@ import pandas as pd
 import shutil
 from pathlib import Path
 from mgnify_pipelines_toolkit.analysis.shared.dwc_summary_generator import get_asv_dict, get_closedref_dict
+from click.testing import CliRunner
+from mgnify_pipelines_toolkit.analysis.shared.dwc_summary_generator import cli
 
 
 def test_get_asv_dict_empty_files(tmp_path: Path):
@@ -126,3 +128,68 @@ def test_get_closedref_dict_empty_files(tmp_path: Path):
     res = get_closedref_dict(runs_df, root_path, db, otu_dir)
     assert run_acc in res
     assert res[run_acc].iloc[0]["count"] == 10
+
+
+def test_generate_dwcready_summaries_single_run_empty_asv(tmp_path: Path):
+    """
+    Test generate_dwcready_summaries when there is a single run but ASV parsing
+    returns an empty dict due to empty critical files.
+
+    Mimics real pipeline structure with minimal required files only.
+    """
+    run_acc = "SRR3612607"
+    # Runs table
+    runs_df = pd.DataFrame([{"run": run_acc, "status": "all_results"}])
+    runs_csv = tmp_path / "runs.csv"
+    runs_df.to_csv(runs_csv, index=False, header=False)
+    # Root structure
+    root_path = tmp_path / "results"
+    run_dir = root_path / run_acc
+    db = "DADA2-SILVA"
+    tax_summary_dir = run_dir / "taxonomy-summary" / db
+    asv_dir = run_dir / "asv"
+    count_dir = asv_dir / "16S-V4"
+    tax_summary_dir.mkdir(parents=True)
+    count_dir.mkdir(parents=True)
+    # Empty mseq file → should cause get_asv_dict to skip run
+    (tax_summary_dir / f"{run_acc}_{db}.mseq").touch()
+    # Other required files exist but are valid
+    (asv_dir / f"{run_acc}_{db}_asv_tax.tsv").write_text("ASV\tKingdom\nASV1\tBacteria\n")
+    (asv_dir / f"{run_acc}_asv_seqs.fasta").write_text(">ASV1\nATGC\n")
+    (count_dir / f"{run_acc}_16S-V4_asv_read_counts.tsv").write_text("asv\tcount\nASV1\t10\n")
+    # OTU dir (required by function)
+    otu_dir = tmp_path / "otu"
+    otu_dir.mkdir()
+    fixture_otu = Path("tests/fixtures/refdb_otus/SILVA-SSU.otu")
+    shutil.copy(fixture_otu, otu_dir / "SILVA-SSU.otu")
+    # Closed-reference files
+    db_closed = "SILVA-SSU"
+    # Closedref minimal structure (empty krona file → should be skipped)
+    closedref_dir = root_path / run_acc / "taxonomy-summary" / db_closed
+    closedref_dir.mkdir(parents=True, exist_ok=True)
+    krona_file = closedref_dir / "empty.txt"
+    krona_file.touch()  # empty → triggers skip in get_closedref_dict
+    # Output dir
+    output_dir = tmp_path / "output"
+    # Run script
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "summarise",
+            "-r",
+            str(runs_csv),
+            "-a",
+            str(root_path),
+            "-otu",
+            str(otu_dir),
+            "-p",
+            str(output_dir),
+        ],
+    )
+    # --- Assertions ---
+    # Since get_asv_dict returns empty dict, no ASV-based outputs should be created
+    assert result.exit_code == 0
+    output_files = list(output_dir.glob("*"))
+    assert output_files == [], "Expected no output summaries when ASV dict and closed-reference dict are empty"

--- a/tests/unit/analysis/shared/dwc_summary_generator/test_dwc_summary_generator.py
+++ b/tests/unit/analysis/shared/dwc_summary_generator/test_dwc_summary_generator.py
@@ -174,6 +174,11 @@ def test_generate_dwcready_summaries_single_run_empty_asv(tmp_path: Path):
     # Run script
     runner = CliRunner()
 
+    # Create minimal metadata JSON mapping for the run and pass via -m
+    metadata = {run_acc: {"RunID": run_acc, "SampleID": "SAMPLE1"}}
+    metadata_file = tmp_path / "metadata.json"
+    metadata_file.write_text(pd.io.json.dumps(metadata))
+
     result = runner.invoke(
         cli,
         [
@@ -184,6 +189,8 @@ def test_generate_dwcready_summaries_single_run_empty_asv(tmp_path: Path):
             str(root_path),
             "-otu",
             str(otu_dir),
+            "-m",
+            str(metadata_file),
             "-p",
             str(output_dir),
         ],

--- a/tests/unit/analysis/shared/dwc_summary_generator/test_dwc_summary_generator.yml
+++ b/tests/unit/analysis/shared/dwc_summary_generator/test_dwc_summary_generator.yml
@@ -9,7 +9,7 @@
 - name: dwc_summary_generator_summarise test_correct_args
   tags:
     - dwc_summary_generator
-  command: dwc_summary_generator summarise -a tests/fixtures/study_summary_inputs/amplicon -r tests/fixtures/study_summary_inputs/amplicon/qc_passed_runs_5.csv -p chunk1 -otu tests/fixtures/refdb_otus
+  command: dwc_summary_generator summarise -a tests/fixtures/study_summary_inputs/amplicon -r tests/fixtures/study_summary_inputs/amplicon/qc_passed_runs_5.csv -p chunk1 -otu tests/fixtures/refdb_otus --metadata tests/fixtures/study_summary_inputs/amplicon/qc_passed_runs_5_metadata.json
   files:
     - path: "chunk1_DADA2-PR2_16S-V3-V4_dwcready.csv"
       md5sum: 7ba4911b221dc18db850d46a89341eb2


### PR DESCRIPTION
Resolves:
1) `ValueError("No objects to concatenate") `in dwc summaries generator. Also test was added for this case.
2) `pandas.errors.EmptyDataError: No columns to parse from file` in markergene sumary script 
3) dwc summaries generator calls API to retrieve run and sample metadata. This is redundant, because metadata is called by production. Instead of calling the API metadata now is taken as input from jason file supplied with `--metadata`. It also resolves errors when private data is called by dwc summaries generator 

The latter will also require emgapiv2 patching from https://github.com/EBI-Metagenomics/emgapi-v2/pull/385