### PR TITLE
EMG-9948 Handle empty amplicon result files

### DIFF
--- a/mgnify_pipelines_toolkit/analysis/amplicon/study_summary_generator.py
+++ b/mgnify_pipelines_toolkit/analysis/amplicon/study_summary_generator.py
@@ -87,7 +87,14 @@ def get_tax_file(run_acc: str, analyses_dir: Path, db_label: str) -> Union[Path,
         asv_tax_files = glob.glob(f"{analyses_dir}/{run_acc}/taxonomy-summary/{db_label}/*.txt")
         asv_tax_files = [Path(file) for file in asv_tax_files if "concat" not in file]  # Have to filter out concatenated file if it exists
 
-        tax_file = asv_tax_files
+        non_empty_asv_tax_files = []
+        for file in asv_tax_files:
+            if file.stat().st_size == 0:  # Pipeline can generate ASV files that are empty, so need to skip those.
+                logging.debug(f"File {file} exists but is empty, skipping it.")
+                continue
+            non_empty_asv_tax_files.append(file)
+
+        tax_file = non_empty_asv_tax_files
 
     return tax_file
 

--- a/mgnify_pipelines_toolkit/analysis/shared/dwc_summary_generator.py
+++ b/mgnify_pipelines_toolkit/analysis/shared/dwc_summary_generator.py
@@ -254,6 +254,10 @@ def load_run_metadata_from_json(metadata_path: Path, runs: List[str]) -> Dict[st
                 md["RunID"] = run
             run_df = pd.DataFrame(md, index=[0]).fillna("NA")
             run_metadata[run] = run_df
+        else:
+            raise ValueError(
+                f"Run {run} not found in metadata JSON file {metadata_path}. Please ensure all runs have corresponding metadata entries."
+            )
 
     return run_metadata
 

--- a/mgnify_pipelines_toolkit/analysis/shared/markergene_study_summary.py
+++ b/mgnify_pipelines_toolkit/analysis/shared/markergene_study_summary.py
@@ -87,14 +87,16 @@ def add_markergene(root_path, run_acc, markergene_dict, markergene):
 
 
 def add_read_count_to_markergene(marker_gene_dict, marker, label):
-    if marker and marker[0].stat().st_size > 0:
-        read_count = get_read_count(str(marker[0]))
-        marker_gene_dict[label]["read_count"] = read_count
-    else:
-        if marker:
-            logging.debug(f"File {marker[0]} exists but is empty, so will be treating its read count as 0.")
-        marker_gene_dict[label]["read_count"] = 0
+    read_count = 0
 
+    if marker:
+        file_path = marker[0]
+        if file_path.stat().st_size > 0:
+            read_count = get_read_count(str(file_path))
+        else:
+            logging.debug(f"File {file_path} exists but is empty, so will be treating its read count as 0.")
+
+    marker_gene_dict[label]["read_count"] = read_count
     return marker_gene_dict
 
 

--- a/mgnify_pipelines_toolkit/analysis/shared/markergene_study_summary.py
+++ b/mgnify_pipelines_toolkit/analysis/shared/markergene_study_summary.py
@@ -87,10 +87,12 @@ def add_markergene(root_path, run_acc, markergene_dict, markergene):
 
 
 def add_read_count_to_markergene(marker_gene_dict, marker, label):
-    if marker:
+    if marker and marker[0].stat().st_size > 0:
         read_count = get_read_count(str(marker[0]))
         marker_gene_dict[label]["read_count"] = read_count
     else:
+        if marker:
+            logging.debug(f"File {marker[0]} exists but is empty, so will be treating its read count as 0.")
         marker_gene_dict[label]["read_count"] = 0
 
     return marker_gene_dict
@@ -124,7 +126,7 @@ def main():
             read_count = 0
             for domain in markergene_dict[run_acc]["marker_genes"][markergene].keys():
                 read_count += markergene_dict[run_acc]["marker_genes"][markergene][domain]["read_count"]
-                proportion = read_count / float(total_read_counts)
+                proportion = read_count / float(total_read_counts) if total_read_counts else 0.0
                 markergene_dict[run_acc]["marker_genes"][markergene][domain]["majority_marker"] = proportion >= MAJORITY_MARKER_PROPORTION
 
     if markergene_dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgnify_pipelines_toolkit"
-version = "1.5.3"
+version = "1.5.4"
 readme = "README.md"
 license = { text = "Apache Software License 2.0" }
 authors = [


### PR DESCRIPTION
This PR fixes failures during study summary generation. Error trace:
```
File "/nfs/production/rdf/metagenomics/jenkins-slurm/dev-prefect-agent/venv/lib/python3.12/site-packages/mgnify_pipelines_toolkit/analysis/amplicon/study_summary_generator.py", line 287, in summarise_analyses
    generate_db_summary(db_label, tax_files, output_prefix)
  File "/nfs/production/rdf/metagenomics/jenkins-slurm/dev-prefect-agent/venv/lib/python3.12/site-packages/mgnify_pipelines_toolkit/analysis/amplicon/study_summary_generator.py", line 180, in generate_db_summary
    amp_region_df = parse_one_tax_file(run_acc, tax_df, long_tax_ranks)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nfs/production/rdf/metagenomics/jenkins-slurm/dev-prefect-agent/venv/lib/python3.12/site-packages/mgnify_pipelines_toolkit/analysis/amplicon/study_summary_generator.py", line 119, in parse_one_tax_file
    res_df["full_taxon"] = res_df.iloc[:, 1:].apply(lambda x: ";".join(x).strip(";"), axis=1)
    ~~~~~~^^^^^^^^^^^^^^
  File "/nfs/production/rdf/metagenomics/jenkins-slurm/dev-prefect-agent/venv/lib/python3.12/site-packages/pandas/core/frame.py", line 4301, in __setitem__
    self._set_item_frame_value(key, value)
  File "/nfs/production/rdf/metagenomics/jenkins-slurm/dev-prefect-agent/venv/lib/python3.12/site-packages/pandas/core/frame.py", line 4459, in _set_item_frame_value
    raise ValueError(
ValueError: Cannot set a DataFrame with multiple columns to the single column full_taxon
```
Robot analysis in case you're curious:

> Here's the root cause:
> 
> Empty ASV taxonomy file. In your input folder, run ERR14650729 has two 0-byte files:
> - ERR14650729/taxonomy-summary/DADA2-PR2/ERR14650729_16S-V3-V4_DADA2-PR2_asv_krona_counts.txt
> - ERR14650729/taxonomy-summary/DADA2-SILVA/ERR14650729_16S-V3-V4_DADA2-SILVA_asv_krona_counts.txt
> 
> When parse_one_tax_file reads one of these with pd.read_csv, it produces a 0-row DataFrame (correct columns, no data). The bug is at study_summary_generator.py:119:
> 
> res_df["full_taxon"] = res_df.iloc[:, 1:].apply(lambda x: ";".join(x).strip(";"), axis=1)
> 
> DataFrame.apply(..., axis=1) on an empty DataFrame is a well-known pandas gotcha: instead of returning an empty Series (one output per row), pandas has nothing to iterate over and just returns the input DataFrame unchanged — a DataFrame with multiple columns, not a Series. Assigning a multi-column DataFrame to a single new column (res_df["full_taxon"] = ...) then raises exactly the ValueError: Cannot set a DataFrame with multiple columns to the single column full_taxon you saw.
> 
> I verified this directly against your data — reading that empty file with the same pd.read_csv(..., names=[...]) call used in the script produces a (0, 10) DataFrame, and applying the same lambda on it returns a DataFrame instead of a Series.
> 
> Why the closed-reference path doesn't hit this: find_tax_file_paths (lines 79–83) already skips empty closed-reference (TAXDB_LABELS) files via a file_size == 0 check. But that check is only applied in the TAXDB_LABELS branch — the ASV path (ASV_TAXDB_LABELS, lines 84–90) collects *.txt files with glob and never checks for empty files before parsing them, so an empty ASV file slips through to parse_one_tax_file and crashes.
> 
> Fix: add the same empty-file skip to the ASV branch, filtering out zero-byte files from asv_tax_files before returning.

And also I added 2 small additional changed that I explained below in comments: